### PR TITLE
Update child version with BCG2 crash fix

### DIFF
--- a/opensrp-giz-malawi/build.gradle
+++ b/opensrp-giz-malawi/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 
     //implementation (project (":opensrp-opd")) {
-    implementation('org.smartregister:opensrp-client-opd:0.0.9-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-opd:0.0.10-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'
@@ -147,12 +147,13 @@ dependencies {
         exclude group: 'com.android.support', module: 'appcompat-v7'
     }
 
-    implementation('org.smartregister:opensrp-client-child:0.1.14-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-child:0.1.16-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'
         exclude group: 'org.smartregister', module: 'opensrp-client-configurable-views'
         exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.github.ybq', module: 'Android-SpinKit'
     }
 
     implementation('org.smartregister:opensrp-client-anc:0.0.7-SNAPSHOT@aar') {
@@ -221,7 +222,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.1.5'
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'com.github.lecho:hellocharts-android:v1.5.8'
-    implementation 'id.zelory:compressor:1.0.4'
+    implementation 'id.zelory:compressor:2.1.0'
     implementation('com.android.support:design:28.0.0') {
         exclude group: 'com.android.support', module: 'recyclerview-v7'
         exclude group: 'com.android.support', module: 'cardview-v7'


### PR DESCRIPTION
This PR requires child version `0.1.16-SNAPSHOT` from the following PRs https://github.com/OpenSRP/opensrp-client-child/pull/91 and https://github.com/OpenSRP/opensrp-client-immunization/pull/110